### PR TITLE
Fix generator spec

### DIFF
--- a/app/services/census_service.rb
+++ b/app/services/census_service.rb
@@ -4,17 +4,17 @@ class CensusService
     @connection = Faraday.new(url: "http://api.census.gov/data/")
   end
 
+  def save_poverty_data(year)
+    data = parse(get_poverty_data(year))
+    PovertyDataGenerator.call(data, year)
+  end
+
   def get_poverty_data(year)
     @connection.get do |req|
       req.url "#{year}/acs5", key: Figaro.env.census_key
       req.params["get"] = generate_tables("B17001")
       req.params["for"] = all_states
     end
-  end
-
-  def save_poverty_data(year)
-    data = parse(get_poverty_data(year))
-    PovertyDataGenerator.call(data, year)
   end
 
   def generate_tables(table_number)

--- a/spec/generators/poverty_data_generator_spec.rb
+++ b/spec/generators/poverty_data_generator_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe CensusService do
-  let(:generator) { PovertyDataGenerator.new }
-
   it "creates a StatePovertyData object from the api data arrays" do
     data = [["B17001_001E","B17001_002E","B17001_003E","B17001_004E",
             "B17001_005E","B17001_006E","B17001_007E","B17001_008E",
@@ -20,10 +18,7 @@ RSpec.describe CensusService do
             "19792","6699","13010","66482",
             "68221","48964","47968","36666",
             "22773","27573","01"]]
-    generator.call(data)
+    PovertyDataGenerator.call(data, 2010)
     expect(StatePovertyData.count).to eql(1)
   end
-
-
-
 end


### PR DESCRIPTION
2 commits: 
- fixed generator spec, it wasnt finished/working, just completed what we already had started
- refactored census_service to remove data_pulling duplication as suggested by Steve
  - so instead of a the #save_poverty_data calling #get_poverty_data(year), its calling a more general #get_data method where a 'table name' and a number of columns are passed in as the arguments, so #get_data('poverty', 30, 2010), specs are still green
